### PR TITLE
HDFS-14646. Standby NameNode should terminate the FsImage put process…

### DIFF
--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageServlet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ImageServlet.java
@@ -597,7 +597,15 @@ public class ImageServlet extends HttpServlet {
     } catch (Throwable t) {
       String errMsg = "PutImage failed. " + StringUtils.stringifyException(t);
       response.sendError(HttpServletResponse.SC_GONE, errMsg);
-      throw new IOException(errMsg);
+      /*
+       *  Do not throw exceptions here to prevent Jetty from printing too
+       *  many unnecessary warn logs, since it is very likely that the peer
+       *  Standby NameNode is testing whether it needs to really put an image.
+       *
+       *  Note the peer Standby NameNode's log will still contain the complete
+       *  warnings.
+       */
+      return;
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/TransferFsImage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/TransferFsImage.java
@@ -268,12 +268,16 @@ public class TransferFsImage {
   private static void uploadImage(URL url, Configuration conf,
       NNStorage storage, NameNodeFile nnf, long txId, Canceler canceler)
       throws IOException {
+    // Check whether we really need to put a FsImage to the peer NameNode.
+    checkShouldPut(url, conf, storage, nnf, txId);
 
-    File imageFile = storage.findImageFile(nnf, txId);
-    if (imageFile == null) {
-      throw new IOException("Could not find image with txid " + txId);
-    }
-
+    // Write the file to output stream.
+    writeFileToPutRequest(url, conf, storage, nnf, txId, canceler);
+  }
+  
+  private static HttpURLConnection setupConnection(URL url, File imageFile,
+      Configuration conf, NNStorage storage, NameNodeFile nnf, long txId)
+          throws IOException{
     HttpURLConnection connection = null;
     try {
       URIBuilder uriBuilder = new URIBuilder(url.toURI());
@@ -310,18 +314,50 @@ public class TransferFsImage {
       // set headers for verification
       ImageServlet.setVerificationHeadersForPut(connection, imageFile);
 
-      // Write the file to output stream.
-      writeFileToPutRequest(conf, connection, imageFile, canceler);
-
-      int responseCode = connection.getResponseCode();
-      if (responseCode != HttpURLConnection.HTTP_OK) {
-        throw new HttpPutFailedException(String.format(
-            "Image uploading failed, status: %d, url: %s, message: %s",
-            responseCode, urlWithParams, connection.getResponseMessage()),
-            responseCode);
-      }
-    } catch (AuthenticationException | URISyntaxException e) {
+      connection.setRequestProperty(Util.CONTENT_TYPE, "application/octet-stream");
+      connection.setRequestProperty(Util.CONTENT_TRANSFER_ENCODING, "binary");
+      return connection;
+    } catch (AuthenticationException e) {
       throw new IOException(e);
+    } catch (URISyntaxException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /*
+   * Current NameNode should terminate put as soon as possible to save
+   * time and bandwidth if the peer NameNode replies something unexpected
+   * (i.e. peer NameNode replies a NOT_ACTIVE_NAMENODE_FAILURE).
+   * */
+  private static void checkShouldPut(URL url, Configuration conf,
+      NNStorage storage, NameNodeFile nnf, long txId)
+      throws HttpPutFailedException, IOException {
+    File imageFile = storage.findImageFile(nnf, txId);
+    if (imageFile == null) {
+      throw new IOException("Could not find image with txid " + txId);
+    }
+
+    HttpURLConnection connection = null;
+    try {
+      connection = setupConnection(url, imageFile, conf, storage, nnf, txId);
+
+      // Connect the peer NameNode and write request.
+      connection.getOutputStream();
+
+     /*
+      * Note if the peer NN is indeed the Active NameNode AND it's now
+      * in the appropriate state to receive our image, then getResponseCode()
+      * will return an HTTP response 410 (HttpServletResponse.SC_GONE, which
+      * is TransferResult.UNEXPECTED_FAILURE), this is because getResponseCode()
+      * will internally close the HTTP connection.
+      */
+      int responseCode = connection.getResponseCode();
+      TransferResult result = TransferResult.getResultForCode(responseCode);
+      if (result == TransferResult.AUTHENTICATION_FAILURE
+          || result == TransferResult.NOT_ACTIVE_NAMENODE_FAILURE
+          || result == TransferResult.OLD_TRANSACTION_ID_FAILURE) {
+        throw new HttpPutFailedException(result.toString(), responseCode);
+      }
     } finally {
       if (connection != null) {
         connection.disconnect();
@@ -329,17 +365,36 @@ public class TransferFsImage {
     }
   }
 
-  private static void writeFileToPutRequest(Configuration conf,
-      HttpURLConnection connection, File imageFile, Canceler canceler)
-      throws IOException {
-    connection.setRequestProperty(Util.CONTENT_TYPE, "application/octet-stream");
-    connection.setRequestProperty(Util.CONTENT_TRANSFER_ENCODING, "binary");
-    OutputStream output = connection.getOutputStream();
-    FileInputStream input = new FileInputStream(imageFile);
+  private static void writeFileToPutRequest(URL url, Configuration conf,
+      NNStorage storage, NameNodeFile nnf, long txId,
+      Canceler canceler) throws IOException {
+    File imageFile = storage.findImageFile(nnf, txId);
+    if (imageFile == null) {
+      throw new IOException("Could not find image with txid " + txId);
+    }
+
+    HttpURLConnection connection = null;
+    OutputStream output = null;
+    FileInputStream input = null;
     try {
+      connection = setupConnection(url, imageFile, conf, storage, nnf, txId);
+
+      output = connection.getOutputStream();
+      input = new FileInputStream(imageFile);
       copyFileToStream(output, imageFile, input,
           ImageServlet.getThrottler(conf), canceler);
+
+      int responseCode = connection.getResponseCode();
+      if (responseCode != HttpURLConnection.HTTP_OK) {
+        throw new HttpPutFailedException(String.format(
+            "Image uploading failed, status: %d, url: %s, message: %s",
+            responseCode, connection.getURL(), connection.getResponseMessage()),
+            responseCode);
+      }
     } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
       IOUtils.closeStream(input);
       IOUtils.closeStream(output);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/ha/StandbyCheckpointer.java
@@ -246,7 +246,6 @@ public class StandbyCheckpointer {
     for (; i < uploads.size(); i++) {
       Future<TransferFsImage.TransferResult> upload = uploads.get(i);
       try {
-        // TODO should there be some smarts here about retries nodes that are not the active NN?
         if (upload.get() == TransferFsImage.TransferResult.SUCCESS) {
           success = true;
           //avoid getting the rest of the results - we don't care since we had a successful upload


### PR DESCRIPTION
Standby NameNode should terminate the FsImage put process immediately if the peer NN is not in the appropriate state to receive an image.